### PR TITLE
Implement repository variables for OWNER and REPO in workflow

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -31,5 +31,7 @@ jobs:
       - name: Generate Updated README
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
+          OWNER: ${{ vars.OWNER }}
+          REPO: ${{ vars.REPO }}
         run: python main.py
           

--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ def format_data_for_openai(diffs, file_content, commit_messages):
 
 def main():
     # Example owner, repo, and PR number - replace with dynamic values as necessary
-    owner = os.getenv('GITHUB_OWNER')
-    repo = os.getenv('GITHUB_REPO')
+    owner = os.getenv('OWNER')
+    repo = os.getenv('REPO')
     pull_request_number = 3
 
     # Fetch README content, PR diffs, and commit messages

--- a/test_github_api.py
+++ b/test_github_api.py
@@ -34,8 +34,8 @@ def test_get_contents_of_file(owner, repo, path):
     print(response)
 
 if __name__ == '__main__':
-    owner = os.getenv('GITHUB_OWNER')
-    repo = os.getenv('GITHUB_REPO')
+    owner = os.getenv('OWNER')
+    repo = os.getenv('REPO')
     pull_request_number = '3'
     path = 'README.md'
 


### PR DESCRIPTION
This PR introduces the use of repository variables to dynamically set the `OWNER` and `REPO` within the GitHub Actions workflow. By leveraging the `vars` context, the workflow gains flexibility and becomes more portable, allowing others to easily adopt and use this action in different contexts without modifying the script.

Changes:
- Added `OWNER` and `REPO` as repository variables in GitHub settings.
- Updated the workflow to utilize `vars.OWNER` and `vars.REPO` for greater dynamism.

This update is a step towards making our GitHub Actions scripts more adaptable for various use cases and user configurations.
